### PR TITLE
Add ability to override tmp directory + fix tests

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,7 @@ pub const EDITOR_KEY: &str = "VISUAL";
 pub const ALWAYS_DELETE_KEY: &str = "ATMPT_ALWAYS_DELETE";
 pub const ALWAYS_KEEP_KEY: &str = "ATMPT_ALWAYS_KEEP";
 pub const DATA_DIR_KEY: &str = "ATMPT_DATA_DIR";
+pub const TMP_DIR_KEY: &str = "ATMPT_TMP_DIR";
 
 #[derive(Debug, Parser)]
 #[command(author, version, about)]
@@ -33,8 +34,11 @@ pub struct Atmpt {
     )]
     pub keep: bool,
 
-    #[arg(long, hide_env = true, env = DATA_DIR_KEY, help = "Override data directory")]
+    #[arg(long, hide_env = true, env = DATA_DIR_KEY, help = "Override templates directory")]
     pub data_dir: Option<String>,
+
+    #[arg(long, short, env = DATA_DIR_KEY, help = "Override attempts directory")]
+    pub tmp_dir: Option<String>,
 }
 
 #[derive(Debug, Parser)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,7 +37,7 @@ pub struct Atmpt {
     #[arg(long, hide_env = true, env = DATA_DIR_KEY, help = "Override templates directory")]
     pub data_dir: Option<String>,
 
-    #[arg(long, short, env = DATA_DIR_KEY, help = "Override attempts directory")]
+    #[arg(long, short, env = TMP_DIR_KEY, help = "Override attempts directory")]
     pub tmp_dir: Option<String>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,15 +18,18 @@ use std::{
 use anyhow::{bail, Context, Ok};
 use chrono::Local;
 
+pub const PROGRAM_NAME: &str = "atmpt";
+const SESSION_FILE_NAME: &str = ".atmpt.json";
+
 pub fn get_atmpt_dir(tmp_dir: &Option<PathBuf>) -> Cow<PathBuf> {
     match tmp_dir {
         Some(d) => Cow::Borrowed(d),
-        None => Cow::Owned(env::temp_dir().join("atmpt")),
+        None => Cow::Owned(env::temp_dir().join(PROGRAM_NAME)),
     }
 }
 
 pub fn get_session_path(tmp_dir: &Option<PathBuf>) -> PathBuf {
-    get_atmpt_dir(tmp_dir).join("session.json")
+    get_atmpt_dir(tmp_dir).join(SESSION_FILE_NAME)
 }
 
 pub fn try_template(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,18 +52,19 @@ pub fn try_template(
         bail!(e);
     }
 
-    // save session data to file
-    let file = File::create(get_session_path(tmp_dir))?;
-    let session = Session {
-        last_template: template.to_owned(),
-    };
-    serde_json::to_writer(BufWriter::new(file), &session)?;
-
     if should_keep(action)? {
         println!("Saved as {project_dir:?}.");
     } else {
         remove_attempt(&project_dir)?;
     }
+
+    // save session data to file
+    let file = File::create(get_session_path(tmp_dir))?;
+    let session = Session {
+        last_template: template.to_owned(),
+        previous_attempt: project_dir,
+    };
+    serde_json::to_writer(BufWriter::new(file), &session)?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 use directories::ProjectDirs;
 
 fn main() -> anyhow::Result<()> {
-    let Some(dirs) = ProjectDirs::from("me", "marcelohdez", "Atmpt") else {
+    let Some(dirs) = ProjectDirs::from("me", "marcelohdez", atmpt::PROGRAM_NAME) else {
         bail!("Could not generate any directories for this OS!");
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::{
     fs::{self, File},
     io::BufReader,
     path::PathBuf,
+    str::FromStr,
 };
 
 use anyhow::{bail, Context};
@@ -18,9 +19,10 @@ fn main() -> anyhow::Result<()> {
     let args = Atmpt::parse();
     let action = args.after_action();
 
-    let mut data_dir = Cow::Borrowed(dirs.data_dir());
-    if let Some(new_dir) = &args.data_dir {
-        data_dir = Cow::Owned(PathBuf::from(new_dir));
+    let tmp_dir = args.tmp_dir.map(|s| PathBuf::from_str(&s)).transpose()?;
+    let data_dir = match &args.data_dir {
+        Some(new_dir) => Cow::Owned(PathBuf::from_str(new_dir)?),
+        None => Cow::Borrowed(dirs.data_dir()),
     };
 
     if args.required.list_template_dir {
@@ -28,13 +30,13 @@ fn main() -> anyhow::Result<()> {
     } else if args.required.list_templates {
         println!("{}", Templates::try_from(data_dir.as_ref())?);
     } else if args.required.previous {
-        atmpt::summon_and_wait(&args.editor, &last_modified_attempt()?)?;
+        atmpt::summon_and_wait(&args.editor, &last_modified_attempt(&tmp_dir)?)?;
     } else {
         let template = match args.required.template {
             Some(t) => t,
             // assume retry option
             None => {
-                let file = File::open(get_session_path())
+                let file = File::open(get_session_path(&tmp_dir))
                     .context("Could not open session file, have you run atmpt recently?")?;
                 let session: Session = serde_json::from_reader(BufReader::new(file))
                     .context("Failed to read session file!")?;
@@ -43,19 +45,19 @@ fn main() -> anyhow::Result<()> {
             }
         };
 
-        atmpt::try_template(&template, &args.editor, &data_dir, action)?;
+        atmpt::try_template(&template, &args.editor, &data_dir, &tmp_dir, action)?;
     }
 
     Ok(())
 }
 
-fn last_modified_attempt() -> anyhow::Result<PathBuf> {
-    let atmpt_dir = get_atmpt_dir();
+fn last_modified_attempt(tmp_dir: &Option<PathBuf>) -> anyhow::Result<PathBuf> {
+    let atmpt_dir = get_atmpt_dir(tmp_dir);
     if !atmpt_dir.exists() {
         bail!("Could not find atmpt folder, have you run atmpt recently?");
     }
 
-    let entries = fs::read_dir(atmpt_dir)?;
+    let entries = fs::read_dir(atmpt_dir.as_ref())?;
     let mut last = None;
     for entry in entries {
         let entry = entry?;

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,6 +1,25 @@
+use std::{
+    fs::File,
+    io::BufReader,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Session {
     pub last_template: String,
+    pub previous_attempt: PathBuf,
+}
+
+impl Session {
+    pub fn from_file(path: &Path) -> anyhow::Result<Self> {
+        let file = File::open(path)
+            .context("Could not open session file, have you run atmpt recently?")?;
+        let session: Self = serde_json::from_reader(BufReader::new(file))
+            .context("Failed to read session file!")?;
+
+        Ok(session)
+    }
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,75 +1,99 @@
-use std::{env, path::PathBuf};
+use std::{env, ffi::OsStr, fs, path::PathBuf, str::FromStr};
 
-use assert_cmd::Command;
-use atmpt::{ALWAYS_DELETE_KEY, DATA_DIR_KEY, EDITOR_KEY};
-
-const PROJECT_DIR: &str = env!("CARGO_MANIFEST_DIR");
+use assert_cmd::{assert::Assert, Command};
+use atmpt::{get_atmpt_dir, ALWAYS_DELETE_KEY, DATA_DIR_KEY, EDITOR_KEY, TMP_DIR_KEY};
 
 fn cmd() -> Command {
-    env::set_var(EDITOR_KEY, "echo"); // exit on success
-    env::set_var(ALWAYS_DELETE_KEY, "true");
-
-    let templates = PathBuf::from_iter([PROJECT_DIR, "templates"]);
-    env::set_var(DATA_DIR_KEY, templates.to_string_lossy().as_ref());
-
-    Command::cargo_bin("atmpt").unwrap()
+    Command::cargo_bin(atmpt::PROGRAM_NAME).unwrap()
 }
 
-// FIXME: Due to the folder being named with the time of creation, multiple
-// tests using the same language template may clash and fail...
+fn cmd_opts(
+    tmp_dir: &str,
+    args: impl IntoIterator<Item = impl AsRef<OsStr>>,
+    delete_on_exit: bool,
+    clear_tmp_dir: bool,
+) -> Assert {
+    let tmp_dir = get_atmpt_dir(&None).join(tmp_dir);
+    if clear_tmp_dir && tmp_dir.exists() {
+        fs::remove_dir_all(&tmp_dir).unwrap();
+    }
+    fs::create_dir_all(&tmp_dir).unwrap();
+
+    let mut cmd = cmd();
+    if delete_on_exit {
+        cmd.env(ALWAYS_DELETE_KEY, "true");
+    }
+
+    cmd.env(EDITOR_KEY, "echo")
+        .env(
+            DATA_DIR_KEY,
+            PathBuf::from_str(env!("CARGO_MANIFEST_DIR"))
+                .unwrap()
+                .join("templates"), // use templates folder as data directory
+        )
+        .env(TMP_DIR_KEY, tmp_dir)
+        .args(args)
+        .assert()
+}
+
+fn cmd_always_delete(tmp_dir: &str, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Assert {
+    cmd_opts(tmp_dir, args, true, false)
+}
 
 // ======= Failures =======
 #[test]
 fn fail_on_conflicting_opts() {
-    cmd().args(["-l", "-d"]).assert().failure();
+    cmd_always_delete("conflicting_opts", ["-ld"]).failure();
 }
 
 #[test]
 fn fail_on_conflicting_opts_with_template() {
-    cmd().args(["c", "-ld"]).assert().failure();
+    cmd_always_delete("conflicting_opts_templ", ["c", "-ld"]).failure();
 }
 
 #[test]
 fn fail_on_keep_and_delete() {
-    cmd().args(["python", "-ny"]).assert().failure();
+    cmd_always_delete("keep_and_delete", ["python", "-ny"]).failure();
 }
 
 #[test]
 fn fail_on_incorrect_template() {
-    cmd().arg("_blahblah!").assert().failure();
+    cmd_always_delete("incorrect_templ", ["_blahblah!"]).failure();
 }
 
 #[test]
 fn fail_on_incorrect_editor() {
-    cmd().args(["-e", "fakeeditor", "java"]).assert().failure();
+    cmd_always_delete("incorrect_editor", ["-e", "fakeeditor", "java"]).failure();
 }
 
 #[test]
 fn fail_on_no_args() {
-    cmd().assert().failure();
+    cmd_always_delete("no_args", [""]).failure();
 }
 
-// TODO: Some way of setting each test's dir so this does not make pass_on_retry fail
-//
-//#[test]
-//fn fail_on_retry_without_session_data() {
-//    let session = get_session_path();
-//
-//    if session.exists() {
-//        fs::remove_file(get_session_path()).unwrap();
-//    }
-//
-//    cmd().arg("-r").assert().failure();
-//}
+#[test]
+fn fail_on_retry_without_session_data() {
+    cmd_opts("retry_no_session", ["-r"], true, true).failure();
+}
 
 // ======= Successes =======
 #[test]
 fn pass_on_correct_template() {
-    cmd().arg("cpp").assert().success();
+    cmd_always_delete("correct_templ", ["cpp"]).success();
 }
 
-//#[test]
-//fn pass_on_retry() {
-//    cmd().arg("cpp").assert().success();
-//    cmd().arg("-r").assert().success();
-//}
+#[test]
+fn pass_on_retry() {
+    const DIR: &str = "retry";
+
+    cmd_always_delete(DIR, ["cpp"]).success();
+    cmd_always_delete(DIR, ["-r"]).success();
+}
+
+#[test]
+fn pass_on_previous() {
+    const DIR: &str = "previous";
+
+    cmd_opts(DIR, ["c", "-y"], false, false).success(); // keep directory with attempt
+    cmd_always_delete(DIR, ["-p"]).success();
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -94,6 +94,6 @@ fn pass_on_retry() {
 fn pass_on_previous() {
     const DIR: &str = "previous";
 
-    cmd_opts(DIR, ["c", "-y"], false, false).success(); // keep directory with attempt
+    cmd_opts(DIR, ["c", "-y"], false, true).success(); // keep directory with attempt
     cmd_always_delete(DIR, ["-p"]).success();
 }


### PR DESCRIPTION
Adding the ability to override the directory used for attempts allows flexibility in the usage of `atmpt` such as a general purpose new-project-maker by adding e.g. `ATMPT_TMP_DIR=~/myprojects` to your environment.

This also allows the tests to be more consistent by running conflicting ones in separate directories so they do not clash.